### PR TITLE
Autonegate cost like C++ ledger does

### DIFF
--- a/core/general.lisp
+++ b/core/general.lisp
@@ -6,6 +6,8 @@
 
 ;;;_ * General utility functions
 
+(defmacro negatef (place) `(setf ,place (- ,place)))
+
 (defmacro if-let (((var value)) &body body)
   `(let ((,var ,value))
      (if ,var

--- a/parsers/textual/textual.lisp
+++ b/parsers/textual/textual.lisp
@@ -4,6 +4,7 @@
 
 (defpackage :ledger-textual
   (:use :common-lisp :ledger :local-time :periods :cambl :cl-ppcre)
+  (:import-from :ledger negatef)
   (:export *directive-handlers*))
 
 (in-package :ledger-textual)
@@ -193,6 +194,8 @@
               (when cost-expr
                 (with-input-from-string (in cost-expr)
                   (setf cost (cambl:read-amount* in))
+                  (when (minusp (cambl:amount-quantity amount))
+                    (negatef (cambl:amount-quantity cost)))
                   (when (peek-char t in nil)
                     (file-position in 0)
                     (setf cost


### PR DESCRIPTION
C++ ledger automatically adjusts negative costs; for convenience, I guess. See [the relevant bits in textual.cc](https://github.com/ledger/ledger/blob/98cb8b1dc7a0d6ea4964e971dbcaa9ea669dc1f9/src/textual.cc#L1577).

This change increases compatibility between C++ ledger and cl-ledger. Without addressing the issue, errors may happen during processing C++ ledger compatible files, or (worse) erroneous reports can be generated silently.